### PR TITLE
Tag 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "css-mashlib",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "css-mashlib",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@solid/community-server": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-mashlib",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CSS with mashlib recipe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Doing this via a PR is not best practice for version tagging, they should usually be tagged on the main branch, but it's good that with this PR we can bring the repo content on GitHub in line with what was published to npm, at least.